### PR TITLE
Fix pre-commit error

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -14,5 +14,7 @@ poetry config virtualenvs.in-project true
 poetry install --no-root
 poetry run pip install git+https://github.com/rinnakk/japanese-clip.git
 poetry run pre-commit install
+VENV=`poetry env info -p`
+echo "source ${VENV}/bin/activate" >> ~/.bashrc
 
 echo "FINISH Install"


### PR DESCRIPTION
VS Codeのソースコードコントロール画面で、pre-commitの時に、.venvのパスが通っていないためにエラーが発生するのを回避するために、postCreateCommand.shで.bashrcに処理を1行追加して回避するように変更

Add source activate for using  pre-commit with VS Code Source Control